### PR TITLE
Change CDN from RawGit to Unpkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Several quick start options are available:
 ``` html
 
 <!-- Latest compiled and minified CSS -->
-<link rel="stylesheet" href="https://cdn.rawgit.com/mblode/marx/master/css/marx.min.css">
+<link rel="stylesheet" href="https://unpkg.com/marx-css/css/marx.min.css">
 
 ```
 - [Source code.](https://raw.githubusercontent.com/mblode/marx/master/css/marx.min.css)


### PR DESCRIPTION
As of October 2018, [RawGit has reached the end of its useful life](https://rawgit.com/). After October 2019, it will stop serving URLs.

This pull request changes the CDN link to Unpkg, which works in a similar way, except for using NPM releases instead of GitHub.