### PR TITLE
Fix word-break on inputs

### DIFF
--- a/scss/_form.scss
+++ b/scss/_form.scss
@@ -25,6 +25,7 @@ textarea {
   line-height: 1.5;
   transition: border-color .15s ease-in-out, box-shadow .15s ease-in-out;
   font-family: $sans-serif;
+  word-break: normal;
 }
 
 input[type="color"], {
@@ -48,6 +49,7 @@ input:not([type]) {
   line-height: 1.5;
   transition: border-color .15s ease-in-out, box-shadow .15s ease-in-out;
   text-align: left;
+  word-break: normal;
 }
 
 input[type="text"]:focus,


### PR DESCRIPTION
Fixes #51. Lmk if you have any questions, thanks.

Screenshot with this fix:
<img width="492" alt="Screen Shot 2020-07-08 at 13 29 53" src="https://user-images.githubusercontent.com/67394526/86968549-35dd5280-c121-11ea-9666-7e5fe0aa1825.png">